### PR TITLE
APM-1690: Deploy all branches to PyPI

### DIFF
--- a/.devops/deploy.sh
+++ b/.devops/deploy.sh
@@ -10,18 +10,16 @@ VERSION_SIMPLE=$(cat ~/.version | xargs | cut -f1 -d"+")
 VERSION_PEP440=$(cat ~/.version440)
 export TIMESTAMP="$(date --rfc-3339=seconds | sed 's/ /T/')"
 
-if [[ "$ENVDIR" == "release" ]]; then
-  echo 'Deploying to PyPI...'
-  # Make and upload the distribution.
-  # Update setuptools so we have a version that supports Markdown READMEs.
-  # twine is also required.
-  mkdir -p auklet/licenses
-  cp LICENSE auklet/licenses/auklet
-  sudo pip install -U setuptools twine wheel
-  python setup.py sdist bdist_wheel
-  if [[ "$TWINE_REPOSITORY_URL" != "" ]]; then
-    twine upload --repository-url $TWINE_REPOSITORY_URL dist/*
-  else
-    twine upload dist/*
-  fi
+echo 'Deploying to PyPI...'
+# Make and upload the distribution.
+# Update setuptools so we have a version that supports Markdown READMEs.
+# twine is also required.
+mkdir -p auklet/licenses
+cp LICENSE auklet/licenses/auklet
+sudo pip install -U setuptools twine wheel
+python setup.py sdist bdist_wheel
+if [[ "$TWINE_REPOSITORY_URL" != "" ]]; then
+  twine upload --repository-url $TWINE_REPOSITORY_URL dist/*
+else
+  twine upload dist/*
 fi


### PR DESCRIPTION
Despite my beliefs to the contrary, PyPI appears to support pre-release deployments with no additional effort required. Here's an example of a project that does so: https://pypi.org/project/macdaily/#history.

This PR removes the prod-only constraint on deploying to PyPI.